### PR TITLE
feat: ignore null characters when they are at the end of a telegram

### DIFF
--- a/src/parsers/dsmr.ts
+++ b/src/parsers/dsmr.ts
@@ -68,7 +68,7 @@ export const DSMRParser = (options: DSMRParserOptions): DSMRParserResult => {
           valid: false,
         };
       }
-    } else if (line === '') {
+    } else if (line === '' || line === '\0') {
       // skip empty lines
     } else {
       // Decode cosem object

--- a/src/parsers/stream-unencrypted.ts
+++ b/src/parsers/stream-unencrypted.ts
@@ -25,7 +25,7 @@ export class UnencryptedDSMRStreamParser implements DSMRStreamParser {
     // End of frame is \r\n!<CRC>\r\n with the CRC being optional as
     // it is only for DSMR 4 and up.
     this.eofRegex =
-      options.newLineChars === '\n' ? /\n!([0-9A-Fa-f]+)?\n/ : /\r\n!([0-9A-Fa-f]+)?\r\n/;
+      options.newLineChars === '\n' ? /\n!([0-9A-Fa-f]+)?\n(\0)?/ : /\r\n!([0-9A-Fa-f]+)?\r\n(\0)?/;
   }
 
   private onData(dataRaw: Buffer) {


### PR DESCRIPTION
Some meters have a `\0` character at the eind of their telegram. This should be ignored