### PR TITLE
Feat/timeouts

### DIFF
--- a/src/parsers/stream.ts
+++ b/src/parsers/stream.ts
@@ -1,9 +1,9 @@
 import { Readable } from 'node:stream';
-import { DSMRParserOptions } from '../index.js';
 import {
   DSMRStreamCallback,
   EncryptedDSMRStreamParser,
   DSMRStreamParser as DSMRStreamParserType,
+  DSMRStreamParserOptions,
 } from './stream-encrypted.js';
 import { UnencryptedDSMRStreamParser } from './stream-unencrypted.js';
 
@@ -18,7 +18,7 @@ import { UnencryptedDSMRStreamParser } from './stream-unencrypted.js';
  */
 export const DSMRStreamParser = (
   stream: Readable,
-  options: Omit<DSMRParserOptions, 'telegram'>,
+  options: Omit<DSMRStreamParserOptions, 'telegram'>,
   callback: DSMRStreamCallback,
 ): DSMRStreamParserType => {
   if (options.decryptionKey) {

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -49,3 +49,10 @@ export class DSMRDecryptionRequired extends DSMRDecodeError {
     this.name = 'DSMRDecryptionRequired';
   }
 }
+
+export class DSMRTimeoutError extends DSMRDecodeError {
+  constructor() {
+    super('Timeout while waiting for full frame');
+    this.name = 'DSMRTimeoutError';
+  }
+}


### PR DESCRIPTION
We need to add a timeout after the intial header/start of frame is received. Otherwise we could get cases where the buffer with data will never be emptied.